### PR TITLE
Support FW version

### DIFF
--- a/esp/Robot/changelog.txt
+++ b/esp/Robot/changelog.txt
@@ -1,0 +1,8 @@
+changelog:
+
+ver6 - 2025/03/10 - added 'V' (version) command
+ver5 - 2025/02/06 - refactoring, shared config for Matty Mxx
+ver4 - 2025/02/05 - GPS integration
+ver3 - 2025/01/25 - new servo library
+ver2 - 2025/01/14 - real robot control from PC
+ver1 - 2025/01/01 - basic communication, initial Robot commit

--- a/esp/Robot/src/main.cpp
+++ b/esp/Robot/src/main.cpp
@@ -36,9 +36,10 @@ void receiveCommand() {
                   break;
         case 'V': {
           // send current version
-          uint8_t buffer[1];
-          buffer[0] = ROBOT_FW_VERSION;
-          uint8_t length = 1;
+          uint8_t buffer[2];
+          buffer[0] = MATTY;  // serial number
+          buffer[1] = ROBOT_FW_VERSION;
+          uint8_t length = 2;
           comm.send('V', buffer, length);
           break;
         }

--- a/esp/Robot/src/main.cpp
+++ b/esp/Robot/src/main.cpp
@@ -34,6 +34,14 @@ void receiveCommand() {
                   break;
         case 'P': gps.config(comm.rxData.mode);
                   break;
+        case 'V': {
+          // send current version
+          uint8_t buffer[1];
+          buffer[0] = ROBOT_FW_VERSION;
+          uint8_t length = 1;
+          comm.send('V', buffer, length);
+          break;
+        }
       }
     } else {
       comm.confirm('N');

--- a/esp/common/config.h
+++ b/esp/common/config.h
@@ -12,6 +12,8 @@
 
 //#define MATTY 01
 
+#define ROBOT_FW_VERSION  6 // please increase with every change of Robot project (or common library)
+
 #define ROBOT_TIMEOUT   250 // timeout do automatickeho zastaveni, pokud neprijde povel G
 #define CONTROL_PERIOD   20 // perioda rizeni  20 ms (50 Hz)
 #define SCAN_PERIOD       0 // perioda scanovani pro odometrii, default vypnuto

--- a/esp/matty-v3.txt
+++ b/esp/matty-v3.txt
@@ -52,7 +52,7 @@ counter message  data
 version zpráva
 
 counter message  data
- uint8    V      uint8 (version)
+ uint8    V      uint8 (serial number), uint8 (version)
 
 =================================================================  
 bitova negace pro escape

--- a/esp/matty-v3.txt
+++ b/esp/matty-v3.txt
@@ -20,6 +20,7 @@ counter command   data
           L       int16 maxspeed (mm/s) int16 maxsteer (0,01°/s)  ... nastavení maximální rychlosti jízdy a změny úhlu kloubu    
           T       uint16 period (ms)    uint16 timeout (ms)       ... nastavení periody posílání dat z robota a timeout pro příjem povelů
           P       uint8 mode                                      ... nastavení režimu gps (0 - vypnuto, 1 - surová data, 2 - ...)
+          V                                                       ... version
   
 ESP -> PC
 
@@ -46,7 +47,13 @@ gps zpráva (odesílána ihned po přijetí z gps):
 
 counter message  data 
  uint8    P      nmea ($  ... CRLF)
-  
+
+
+version zpráva
+
+counter message  data
+ uint8    V      uint8 (version)
+
 =================================================================  
 bitova negace pro escape
 CRC 8bit soucet/doplnek


### PR DESCRIPTION
Provide 'V' command with single byte version response. Added also "changelog" and updated protocol document.

From the OSGAR point of view it looks like:
```
2025-03-11 07:20:34,037 __main__         INFO     /home/md/git/osgar/matty-go-250311_062034.log
2025-03-11 07:20:34,045 __main__         INFO     SIGINT handler installed
FW version: 6
0:00:00.196041 Bumpers:  
0:00:00.196695 Go!
```